### PR TITLE
 bladeのテンプレートを実装

### DIFF
--- a/src/resources/js/dropdown.js
+++ b/src/resources/js/dropdown.js
@@ -1,0 +1,5 @@
+const dropdownBtn = document.getElementById('dropdown-btn');
+dropdownBtn.addEventListener('click', function() {
+    const menu = document.getElementById('dropdown-menu');
+    menu.classList.toggle('invisible');
+});

--- a/src/resources/views/components/pylon_template.blade.php
+++ b/src/resources/views/components/pylon_template.blade.php
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+        
+        <title>{{ config('app.name', 'Laravel') }}</title>
+
+        <!-- Fonts -->
+        <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Nunito:wght@400;600;700&display=swap">
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Rubik+Distressed&display=swap" rel="stylesheet">
+
+        <!-- Scripts -->
+        @vite(['resources/css/app.css', 'resources/js/app.js', 'resources/js/dropdown.js'])
+    </head>
+    <body class="font-sans antialiased">
+        <div class="min-h-screen bg-gray-100">
+            <!-- Page Heading -->
+            <header class="bg-white shadow">
+                <div class="flex items-center max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+                    <div class="flex-initial w-32 fixed  left-0 px-6 py-3">
+                        <a href="{{ route('main_page') }}">Pylon</a>
+                    </div>
+                    <div class="flex-none fixed  right-0 px-6  py-3 sm:block">
+                        @auth
+                            <button id="dropdown-btn">
+                                <div class="text-sm text-gray-700 dark:text-gray-500 underline hover:font-bold">{{ Auth::user()->name }}</div>
+                            </button>
+                        @else
+                            <a href="{{ route('login') }}" class="text-sm text-gray-700 dark:text-gray-500 underline">Log in</a>
+                            <a href="{{ route('register') }}" class="ml-4 text-sm text-gray-700 dark:text-gray-500 underline">Register</a>
+                        @endauth
+                    </div>
+                </div>
+                {{ $header }}
+            </header>
+            <div id="dropdown-menu" class="invisible bg-white fixed right-0 w-32 h-32 p-8 border border-black">
+                                <a class="my-auto text-gray-700 dark:text-gray-500 underline hover:font-bold" href="{{ url('/dashboard') }}" class="text-sm text-gray-700 dark:text-gray-500 underline">Dashboard</a>
+                                <form class="my-auto" method="POST" action="{{ route('logout') }}">
+                                    @csrf
+                                    <a class="text-gray-700 dark:text-gray-500 underline hover:font-bold" href="{{route('logout') }}" onclick="event.preventDefault(); this.closest('form').submit();">{{ __('Log Out') }}</a>
+                                </form>
+            </div>
+
+            <!-- Page Content -->
+            <main>
+                {{ $slot }}
+            </main>
+        </div>
+    </body>
+</html>

--- a/src/resources/views/main_page.blade.php
+++ b/src/resources/views/main_page.blade.php
@@ -1,39 +1,10 @@
-<!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="csrf-token" content="{{ csrf_token() }}">
-
-        <title>{{ config('app.name', 'Pylon') }}</title>
-
-        <!-- Fonts -->
-        <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Nunito:wght@400;600;700&display=swap">
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Rubik+Distressed&display=swap" rel="stylesheet">
-        <!-- Scripts -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
-    </head>
-    <body class="antialiased">
-        <div class="min-h-screen bg-gray-100">
-            <!-- Page Heading -->
-            <div class="relative flex items-top justify-center min-h-screen bg-gray-100 dark:bg-gray-900 sm:items-center py-4 sm:pt-0">
-                <header class="hidden fixed top-0 right-0 px-6 py-4 sm:block">
-                    @auth
-                        <div>{{ Auth::user()->name }}</div>
-                    @else
-                        <a href="{{ route('login') }}" class="text-sm text-gray-700 dark:text-gray-500 underline">Log in</a>
-                        <a href="{{ route('register') }}" class="ml-4 text-sm text-gray-700 dark:text-gray-500 underline">Register</a>
-                    @endauth
-                </header>
-                <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
-                    <div class="flex justify-center pt-8 sm:justify-start sm:pt-0">
-                        <div class="text-7xl" style="font-family: 'Rubik Distressed', cursive;">Pylon</div>
-                    </div>
-                </div>
+<x-pylon_template>
+    <x-slot name="header"></x-slot>
+    <x-slot name="slot">
+        <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
+            <div class="flex justify-center pt-8 sm:pt-0 text-center text-7xl" style="font-family: 'Rubik Distressed', cursive;">
+                Pylon
             </div>
         </div>
-    </body>
-</html>
-
+    </x-slot>
+</x-pylon_template>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -26,7 +26,7 @@ Route::get(
     function () {
         return view('main_page');
     }
-);
+)->name('main_page');
 
 Route::get('/filelist', [FiledataController::class, 'getFileList']);
 


### PR DESCRIPTION
## やったこと

* このプルリクで何をしたのか？

 - #16 の実装です
 - すべてのページ同じヘッダーを使えるようにテンプレート化しました
 - Pylonのロゴ（文字）を押すとメインページ(/pylon)に戻る
 - ログインしてない時
   - ログイン、登録ボタンの表示
 - ログイン後
   - ユーザーネーム（ボタンになっていて、ダッシュボードやログアウトが選択できる）  　
## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）
  - ログイン、ログアウト時に違うページに行ってしまう点
  - 細かいデザイン、ドロップダウンとかもっと綺麗にできそう
  - 上記2点アサインなしてissueに記載しておきます
    - 持ってるタスクがなくなればやろうと思います
    - 森井君がとっても大丈夫です 

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

  - メインページ
![動作確認](https://user-images.githubusercontent.com/80672452/204139246-5ca4f34d-5588-4cb1-805f-85210902e66e.gif)
のロゴが消えている動画になっていますが（撮影後修正しました）こんな感じです.
  

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
  - `npm run dev`をすでに実行している場合は、いちど止めて再起動お願いします。(cssやjsが効かないと思うので。。。) 