### PR TITLE
メインページにファイル作成ボタンとファイル一覧ボタンを作成

### DIFF
--- a/src/resources/views/components/pylon_template.blade.php
+++ b/src/resources/views/components/pylon_template.blade.php
@@ -11,7 +11,8 @@
         <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Nunito:wght@400;600;700&display=swap">
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Rubik+Distressed&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Rubik+Distressed&display=swap" rel="stylesheet"> 
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300&display=swap" rel="stylesheet">
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js', 'resources/js/dropdown.js'])

--- a/src/resources/views/main_page.blade.php
+++ b/src/resources/views/main_page.blade.php
@@ -6,5 +6,15 @@
                 Pylon
             </div>
         </div>
+        <div class="absolute top-3/4  w-screen">        
+            <div class="flex justify-center text-center">
+                <div class="m-5">            
+                    <a href="{{route('makeFile')}}" class="inline-block w-52 text-xl text-white bg-gray-800 px-7 hover:bg-gray-700 rounded-xl">ファイル作成</a>
+                </div>
+                <div class="m-5">
+                    <a href="{{route('fileList')}}" class="inline-block w-52 text-xl text-white bg-gray-800 px-7 hover:bg-gray-700 rounded-xl">ファイル一覧表示</a>
+                </div>
+            </div>
+        </div>
     </x-slot>
 </x-pylon_template>

--- a/src/resources/views/main_page.blade.php
+++ b/src/resources/views/main_page.blade.php
@@ -9,10 +9,10 @@
         <div class="absolute top-3/4  w-screen">        
             <div class="flex justify-center text-center">
                 <div class="m-5">            
-                    <a href="{{route('makeFile')}}" class="inline-block w-52 text-xl text-white bg-gray-800 px-7 hover:bg-gray-700 rounded-xl">ファイル作成</a>
+                    <a href="{{route('makeFile')}}" class="inline-block w-56 text-xl text-white bg-gray-800 px-7 hover:bg-gray-700 rounded-xl" style="font-family: 'Noto Sans JP', sans-serif;">ファイル作成</a>
                 </div>
                 <div class="m-5">
-                    <a href="{{route('fileList')}}" class="inline-block w-52 text-xl text-white bg-gray-800 px-7 hover:bg-gray-700 rounded-xl">ファイル一覧表示</a>
+                    <a href="{{route('fileList')}}" class="inline-block w-56 text-xl text-white bg-gray-800 px-7 hover:bg-gray-700 rounded-xl" style="font-family: 'Noto Sans JP', sans-serif;">ファイル一覧表示</a>
                 </div>
             </div>
         </div>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -28,9 +28,11 @@ Route::get(
     }
 )->name('main_page');
 
-Route::get('/filelist', [FiledataController::class, 'getFileList']);
+Route::get('/filelist', [FiledataController::class, 'getFileList'])
+    ->middleware(['auth'])->name('fileList');
 
-Route::get('/makefile', [FiledataController::class, 'edit_make_file']);
+Route::get('/makefile', [FiledataController::class, 'edit_make_file'])
+    ->middleware(['auth'])->name('makeFile');
 
 Route::post('/makefile', [FiledataController::class, 'save'])->name('save');
 


### PR DESCRIPTION
## やったこと

* このプルリクで何をしたのか？
  * #15 の対応になります 
  * ファイル作成ボタンと、ファイル一覧表示ボタンを追加
  * 二つのボタンとも認証が済んでいない場合は、先に認証ページにリダイレクトされます。

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）
  * ボタンのデザイン、ボタンの表示している文字は仮で入れてます。
    * 何か要望があればレビューに記載お願いします。 

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？
  - 認証せずにpylonに移動し、二つのボタンを押して動作確認しました。
![スクリーンショット 2022-11-30 004149](https://user-images.githubusercontent.com/80672452/204578564-23b98c04-4606-4722-b451-8fdd3b6641eb.png)

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
  - 特にないです